### PR TITLE
Add install xterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Install:
 
 Open desktopvideo (Decklink GUI) and setup card for 8 input.
 
+### Install "Xterm"
+Ubuntu 18.04 doesn't by default install xterm. Install by
+```
+sudo apt update
+sudo apt install xterm
+```
 ### Install FFmpeg:
 ```
 sudo apt-get install git


### PR DESCRIPTION
Xterm is not installed by default on the tested Ubuntu 18.04. Proposed change to install xterm as part of runbook.